### PR TITLE
configuration gem/paranoia

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,7 +67,7 @@ gem "refile-mini_magick"
 gem 'bootstrap-sass', '~> 3.3.6'
 gem 'jquery-rails'
 gem "cocoon"
-gem 'paranoia'
+gem 'paranoia', '~>2.2'
 gem 'kaminari', '~> 1.1.1'
 gem 'omniauth'
 gem 'omniauth-github'


### PR DESCRIPTION
ge/paranoiaの初期設定

rails versionl5系のため
paranoia '~>2.2'を指定